### PR TITLE
Avoid console.warn with superagent 2.x

### DIFF
--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -171,7 +171,8 @@ function mock (superagent, config, logger) {
             getResponseHeader: function () {return err.responseHeader || 'a header';}
           }
         });
-        response.setStatusProperties(err.message);
+        var method = response._setStatusProperties ? '_setStatusProperties' : 'setStatusProperties'
+        response[method](err.message);
       }
 
       fn(error, response);


### PR DESCRIPTION
In `superagent@2.x`, the `setStatusProperties` has been deprecated in favor of private `_setStatusProperties`:

https://github.com/visionmedia/superagent/blob/master/lib/node/response.js#L196-L199

This commit will maintain same functionality, avoid the `console.warn` and preserve legacy versions of `superagent`
